### PR TITLE
Add installation file to keep changes after mod cache refresh

### DIFF
--- a/install.xml
+++ b/install.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<modification>
+    <code>icepay_5b0eb44b46ab1</code>
+    <name>ICEPAY module</name>
+    <version>3.0</version>
+    <author>ICEPAY</author>
+    <link>https://github.com/ICEPAY/OpenCart-3.x/</link>
+</modification>


### PR DESCRIPTION
This will add an installation.xml file to the content, so these uploaded file will remain after modification caches have been refreshed. This also shows the module in the "Modifications" tab in opencart admin